### PR TITLE
Fix off-by-one error when checking for last fragment

### DIFF
--- a/Drivers/Z-Wave-Firmware-Updater/zwaveBinaryUpdater.groovy
+++ b/Drivers/Z-Wave-Firmware-Updater/zwaveBinaryUpdater.groovy
@@ -1,8 +1,8 @@
-// v1.00
+// v1.01 fix off-by-one error
 import groovy.transform.Field
 
 metadata {
-    definition (name: "Z-Wave Firmware Updater",namespace: "djdizzyd", author: "Bryan Copeland") {
+    definition (name: "Z-Wave Firmware Updater",namespace: "djdizzyd", author: "Bryan Copeland", importUrl: "https://raw.githubusercontent.com/djdizzyd/hubitat/master/Drivers/Z-Wave-Firmware-Updater/zwaveBinaryUpdater.groovy") {
         attribute "currentFirmwareVersion", "string"
         attribute "firmwareUpdateProgress", "string"
         attribute "firmwareUploadPercent", "string"
@@ -155,7 +155,7 @@ void zwaveEvent(hubitat.zwave.commands.firmwareupdatemdv3.FirmwareUpdateMdGet cm
     if (device.currentValue("firmwareUploadPercent") != "${percent}%") {
         sendEvent(name: "firmwareUploadPercent", value: "${percent}%")
     }
-    if (lastByte >= byteBuffer.size()-1) {
+    if (lastByte >= byteBuffer.size()) {
         lastReport=true
         lastByte = byteBuffer.size()
     }

--- a/Drivers/Z-Wave-Firmware-Updater/zwaveFirmwareUpdater-test.groovy
+++ b/Drivers/Z-Wave-Firmware-Updater/zwaveFirmwareUpdater-test.groovy
@@ -152,7 +152,7 @@ void zwaveEvent(hubitat.zwave.commands.firmwareupdatemdv3.FirmwareUpdateMdGet cm
     if (device.currentValue("firmwareUploadPercent") != "${percent}%") {
         sendEvent(name: "firmwareUploadPercent", value: "${percent}%")
     }
-    if (lastByte >= byteBuffer.size()-1) {
+    if (lastByte >= byteBuffer.size()) {
         lastReport=true
         lastByte = byteBuffer.size()
     }

--- a/Drivers/Z-Wave-Firmware-Updater/zwaveFirmwareUpdater.groovy
+++ b/Drivers/Z-Wave-Firmware-Updater/zwaveFirmwareUpdater.groovy
@@ -1,4 +1,4 @@
-// v1.00
+// v1.01 fix off-by-one error
 import groovy.transform.Field
 
 metadata {
@@ -152,7 +152,7 @@ void zwaveEvent(hubitat.zwave.commands.firmwareupdatemdv3.FirmwareUpdateMdGet cm
     if (device.currentValue("firmwareUploadPercent") != "${percent}%") {
         sendEvent(name: "firmwareUploadPercent", value: "${percent}%")
     }
-    if (lastByte >= byteBuffer.size()-1) {
+    if (lastByte >= byteBuffer.size()) {
         lastReport=true
         lastByte = byteBuffer.size()
     }


### PR DESCRIPTION
I discovered this bug when trying to update my inovelli LZW30 switches to firmware 1.22. The firmware updater worked fine for other firmware files, but not this one. 

The reason is that there's a bug in the logic for checking for whether this is the last fragment, which falsely sets to true when this is the next-to-last fragment and the actual last fragment will only have 1 byte in it. 

This only causes an actual problem when the firmware size is 1 more than a multiple of the fragment size, which is the case with the LZW30 firmware version 1.22 (93601 bytes).

Once I applied this change locally, I was able to successfully update my switches. I successfully flashed multiple firmware files with a variety of sizes, resulting in last-fragment sizes of 40 bytes, 1 byte, and something in between. 

For more context, see https://community.inovelli.com/t/unable-to-update-black-switch-firmware-using-hubitat/9413/2