### PR TITLE
Use zwaveSecureEncap when sending secure commands

### DIFF
--- a/Drivers/Z-Wave-Firmware-Updater/zwaveFirmwareUpdater.groovy
+++ b/Drivers/Z-Wave-Firmware-Updater/zwaveFirmwareUpdater.groovy
@@ -594,11 +594,9 @@ String secureCommand(hubitat.zwave.Command cmd) {
 }
 
 String secureCommand(String cmd) {
-    String encap=""
     if (getDataValue("zwaveSecurePairingComplete") != "true") {
         return cmd
     } else {
-        encap = "988100"
+        return zwaveSecureEncap(cmd)
     }
-    return "${encap}${cmd}"
 }


### PR DESCRIPTION
I was encountering the "Please wake up your sleepy device" message when attempting to update the firmware on my S2-enabled Inovelli dimmers.  This modification allowed the firmware update to proceed.