### PR TITLE
Support Push Button events

### DIFF
--- a/Drivers/zooz/zen21-switch.groovy
+++ b/Drivers/zooz/zen21-switch.groovy
@@ -368,4 +368,21 @@ void zwaveEvent(hubitat.zwave.commands.centralscenev3.CentralSceneNotification c
             sendEvent(evt)
         }
     }
+    
+    /**
+        Handles Push Button events from the Device details which sends them as BigDecimal
+    **/
+    void push(BigDecimal button){
+        Map evt = [name: "pushed", type:"digital", isStateChange:true]
+        evt.value = button
+        evt.descriptionText = "${device.displayName} button ${evt.value} pushed"
+        sendEvent(evt)
+    }
+
+    /**
+        Handles Push Button events from Rule Machine which sends them as Long
+    **/
+    void push(Long button){
+        push(new BigDecimal(button));
+    }
 }


### PR DESCRIPTION
The original drive doesn't support Push Button events from either Rule Machine or from the Device details. Both throw an exception:

groovy.lang.MissingMethodException: No signature of method: user_driver_djdizzyd_Zooz_Zen21_Central_Scene_Switch_383.push() is applicable for argument types: (java.math.BigDecimal) values: [1]

or

groovy.lang.MissingMethodException: No signature of method: user_driver_djdizzyd_Zooz_Zen21_Central_Scene_Switch_383.push() is applicable for argument types: (java.lang.Long) values: [1]

This allows the switch to support virtual button pushes.